### PR TITLE
Prefetch instructions

### DIFF
--- a/src/kernel/bytecode.c
+++ b/src/kernel/bytecode.c
@@ -62,6 +62,7 @@ bool bytecodeInstructionParse(BytecodeInstructionInfo *info, BytecodeInstruction
 		switch(instruction[0]&0xF) {
 			case 0: info->d.misc.type=BytecodeInstructionMiscTypeNop; return true; break;
 			case 1: info->d.misc.type=BytecodeInstructionMiscTypeSyscall; return true; break;
+			case 2: info->d.misc.type=BytecodeInstructionMiscTypeClearInstructionCache; return true; break;
 		}
 
 		return false;
@@ -115,6 +116,10 @@ BytecodeInstructionShort bytecodeInstructionCreateMiscNop(void) {
 
 BytecodeInstructionShort bytecodeInstructionCreateMiscSyscall(void) {
 	return 0xC1;
+}
+
+BytecodeInstructionShort bytecodeInstructionCreateMiscClearInstructionCache(void) {
+	return 0xC2;
 }
 
 BytecodeInstructionStandard bytecodeInstructionCreateMiscSet8(BytecodeRegister destReg, uint8_t value) {

--- a/src/kernel/bytecode.h
+++ b/src/kernel/bytecode.h
@@ -170,6 +170,7 @@ typedef enum {
 typedef enum {
 	BytecodeInstructionMiscTypeNop,
 	BytecodeInstructionMiscTypeSyscall,
+	BytecodeInstructionMiscTypeClearInstructionCache,
 	BytecodeInstructionMiscTypeSet8,
 	BytecodeInstructionMiscTypeSet16,
 } BytecodeInstructionMiscType;
@@ -210,6 +211,7 @@ BytecodeInstructionStandard bytecodeInstructionCreateAlu(BytecodeInstructionAluT
 BytecodeInstructionStandard bytecodeInstructionCreateAluIncDecValue(BytecodeInstructionAluType type, BytecodeRegister destReg, uint8_t incDecValue);
 BytecodeInstructionShort bytecodeInstructionCreateMiscNop(void);
 BytecodeInstructionShort bytecodeInstructionCreateMiscSyscall(void);
+BytecodeInstructionShort bytecodeInstructionCreateMiscClearInstructionCache(void);
 BytecodeInstructionStandard bytecodeInstructionCreateMiscSet8(BytecodeRegister destReg, uint8_t value);
 void bytecodeInstructionCreateMiscSet16(BytecodeInstructionLong instruction, BytecodeRegister destReg, uint16_t value);
 

--- a/src/kernel/procman.c
+++ b/src/kernel/procman.c
@@ -139,7 +139,7 @@ bool procManProcessGetInstruction(ProcManProcess *process, ProcManProcessProcDat
 bool procManProcessExecInstruction(ProcManProcess *process, ProcManProcessProcData *procData, BytecodeInstructionLong instruction, ProcManPrefetchData *prefetchData, ProcManExitStatus *exitStatus);
 bool procManProcessExecInstructionMemory(ProcManProcess *process, ProcManProcessProcData *procData, const BytecodeInstructionInfo *info, ProcManExitStatus *exitStatus);
 bool procManProcessExecInstructionAlu(ProcManProcess *process, ProcManProcessProcData *procData, const BytecodeInstructionInfo *info, ProcManPrefetchData *prefetchData, ProcManExitStatus *exitStatus);
-bool procManProcessExecInstructionMisc(ProcManProcess *process, ProcManProcessProcData *procData, const BytecodeInstructionInfo *info, ProcManExitStatus *exitStatus);
+bool procManProcessExecInstructionMisc(ProcManProcess *process, ProcManProcessProcData *procData, const BytecodeInstructionInfo *info, ProcManPrefetchData *prefetchData, ProcManExitStatus *exitStatus);
 bool procManProcessExecSyscall(ProcManProcess *process, ProcManProcessProcData *procData, ProcManExitStatus *exitStatus);
 
 void procManProcessFork(ProcManProcess *process, ProcManProcessProcData *procData);
@@ -923,7 +923,7 @@ bool procManProcessExecInstruction(ProcManProcess *process, ProcManProcessProcDa
 			return procManProcessExecInstructionAlu(process, procData, &info, prefetchData, exitStatus);
 		break;
 		case BytecodeInstructionTypeMisc:
-			return procManProcessExecInstructionMisc(process, procData, &info, exitStatus);
+			return procManProcessExecInstructionMisc(process, procData, &info, prefetchData, exitStatus);
 		break;
 	}
 
@@ -1052,13 +1052,16 @@ bool procManProcessExecInstructionAlu(ProcManProcess *process, ProcManProcessPro
 	return true;
 }
 
-bool procManProcessExecInstructionMisc(ProcManProcess *process, ProcManProcessProcData *procData, const BytecodeInstructionInfo *info, ProcManExitStatus *exitStatus) {
+bool procManProcessExecInstructionMisc(ProcManProcess *process, ProcManProcessProcData *procData, const BytecodeInstructionInfo *info, ProcManPrefetchData *prefetchData, ProcManExitStatus *exitStatus) {
 	switch(info->d.misc.type) {
 		case BytecodeInstructionMiscTypeNop:
 		break;
 		case BytecodeInstructionMiscTypeSyscall:
 			if (!procManProcessExecSyscall(process, procData, exitStatus))
 				return false;
+		break;
+		case BytecodeInstructionMiscTypeClearInstructionCache:
+			procManPrefetchDataInit(prefetchData);
 		break;
 		case BytecodeInstructionMiscTypeSet8:
 			procData->regs[info->d.misc.d.set8.destReg]=info->d.misc.d.set8.value;

--- a/src/kernel/procman.c
+++ b/src/kernel/procman.c
@@ -83,7 +83,7 @@ typedef struct {
 	uint16_t baseAddr, len;
 } ProcManPrefetchData;
 
-void procManPrefetchDataInit(ProcManPrefetchData *pd);
+void procManPrefetchDataClear(ProcManPrefetchData *pd);
 bool procManPrefetchDataReadByte(ProcManPrefetchData *pd, ProcManProcess *process, ProcManProcessProcData *procData, uint16_t addr, uint8_t *value);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -460,7 +460,7 @@ void procManProcessTick(ProcManPid pid) {
 
 	// Run a few instructions
 	ProcManPrefetchData prefetchData;
-	procManPrefetchDataInit(&prefetchData);
+	procManPrefetchDataClear(&prefetchData);
 	for(uint16_t instructionNum=0; instructionNum<procManProcessTickInstructionsPerTick; ++instructionNum) {
 		// Run a single instruction
 		BytecodeInstructionLong instruction;
@@ -1061,7 +1061,7 @@ bool procManProcessExecInstructionMisc(ProcManProcess *process, ProcManProcessPr
 				return false;
 		break;
 		case BytecodeInstructionMiscTypeClearInstructionCache:
-			procManPrefetchDataInit(prefetchData);
+			procManPrefetchDataClear(prefetchData);
 		break;
 		case BytecodeInstructionMiscTypeSet8:
 			procData->regs[info->d.misc.d.set8.destReg]=info->d.misc.d.set8.value;
@@ -2037,7 +2037,7 @@ void procManResetInstructionCounters(void) {
 		procManData.processes[i].instructionCounter=0;
 }
 
-void procManPrefetchDataInit(ProcManPrefetchData *pd) {
+void procManPrefetchDataClear(ProcManPrefetchData *pd) {
 	pd->len=0;
 }
 

--- a/src/tools/assembler/assembler.c
+++ b/src/tools/assembler/assembler.c
@@ -75,6 +75,7 @@ typedef enum {
 	AssemblerInstructionTypeMov,
 	AssemblerInstructionTypeLabel,
 	AssemblerInstructionTypeSyscall,
+	AssemblerInstructionTypeClearInstructionCache,
 	AssemblerInstructionTypeAlu,
 	AssemblerInstructionTypeJmp,
 	AssemblerInstructionTypePush8,
@@ -1026,6 +1027,11 @@ bool assemblerProgramParseLines(AssemblerProgram *program) {
 			instruction->lineIndex=i;
 			instruction->modifiedLineCopy=lineCopy;
 			instruction->type=AssemblerInstructionTypeSyscall;
+		} else if (strcmp(first, "clricache")==0) {
+			AssemblerInstruction *instruction=&program->instructions[program->instructionsNext++];
+			instruction->lineIndex=i;
+			instruction->modifiedLineCopy=lineCopy;
+			instruction->type=AssemblerInstructionTypeClearInstructionCache;
 		} else if (strcmp(first, "jmp")==0) {
 			char *addr=strtok_r(NULL, " ", &savePtr);
 			if (addr==NULL) {
@@ -1420,6 +1426,11 @@ bool assemblerProgramGenerateInitialMachineCode(AssemblerProgram *program) {
 				instruction->machineCodeLen=1;
 				instruction->machineCodeInstructions=1;
 			break;
+			case AssemblerInstructionTypeClearInstructionCache:
+				instruction->machineCode[0]=bytecodeInstructionCreateMiscClearInstructionCache();
+				instruction->machineCodeLen=1;
+				instruction->machineCodeInstructions=1;
+			break;
 			case AssemblerInstructionTypeAlu:
 				instruction->machineCodeLen=2; // all ALU instructions take 2 bytes
 				instruction->machineCodeInstructions=1;
@@ -1567,6 +1578,8 @@ bool assemblerProgramComputeFinalMachineCode(AssemblerProgram *program) {
 			case AssemblerInstructionTypeLabel:
 			break;
 			case AssemblerInstructionTypeSyscall:
+			break;
+			case AssemblerInstructionTypeClearInstructionCache:
 			break;
 			case AssemblerInstructionTypeAlu: {
 				// Verify dest is a valid register
@@ -1865,6 +1878,9 @@ void assemblerProgramDebugInstructions(const AssemblerProgram *program) {
 			break;
 			case AssemblerInstructionTypeSyscall:
 				printf("syscall (%s:%u '%s')\n", line->file, line->lineNum, line->original);
+			break;
+			case AssemblerInstructionTypeClearInstructionCache:
+				printf("clricache (%s:%u '%s')\n", line->file, line->lineNum, line->original);
 			break;
 			case AssemblerInstructionTypeAlu:
 				switch(instruction->d.alu.type) {

--- a/src/tools/disassembler/disassembler.c
+++ b/src/tools/disassembler/disassembler.c
@@ -144,6 +144,9 @@ int main(int argc, char **argv) {
 						case BytecodeInstructionMiscTypeSyscall:
 							disassemblerPrint(addr, instruction, "syscall");
 						break;
+						case BytecodeInstructionMiscTypeClearInstructionCache:
+							disassemblerPrint(addr, instruction, "clear icache");
+						break;
 						case BytecodeInstructionMiscTypeSet8:
 							disassemblerPrint(addr, instruction, "r%u=%u", info.d.misc.d.set8.destReg, info.d.misc.d.set8.value);
 						break;

--- a/src/tools/emulator/emulator.c
+++ b/src/tools/emulator/emulator.c
@@ -650,6 +650,9 @@ bool processRunNextInstruction(Process *process) {
 						break;
 					}
 				} break;
+				case BytecodeInstructionMiscTypeClearInstructionCache:
+					// We do not use an instruction cache so nothing to do
+				break;
 				case BytecodeInstructionMiscTypeSet8:
 					process->regs[info.d.misc.d.set8.destReg]=info.d.misc.d.set8.value;
 					if (infoInstructions)


### PR DESCRIPTION
The prefetching part seems to work very well, with ``time fib`` reporting 20s instead of 4m19s.

However this is presumably buggy if a process jumps to the RW part of memory and uses self-modifying code. Options seem to be:
1. Leave the behavior as is and document it so that people are aware such usage could be unpredictable. This is obviously the fastest option for most programs, but does not allow for self-modifying code. In the future perhaps an instruction could be made to clear the instruction cache, which would at least make shared library loading feasible.
2. Avoid prefetching if an address points into the RW part of memory. This is safe and would have almost no speed impact most of the time, except if in the future we implement say shared libraries using RW memory.
3. Still prefetch, but check on every write to process memory if the cache needs invalidating/updating. This could be slow and error prone, but would be safe and also have the benefit of being able to prefetch RW addresses also.